### PR TITLE
Fix Azure SWA build after changing the app structure.

### DIFF
--- a/adapters/azure-swa/vite.config.ts
+++ b/adapters/azure-swa/vite.config.ts
@@ -22,7 +22,7 @@ export default extendConfig(baseConfig, () => {
     plugins: [
       azureSwaAdapter({
         ssg: {
-          include: ["/", "/static/*"],
+          include: ["/static/*"],
         },
       }),
     ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "qwik-city-e2e",
   "private": true,
   "scripts": {
-    "build.azure": "npm run build.client && vite build -c adapters/azure-swa/vite.config.ts",
+    "build.azure": "npm run build.client && vite build -c adapters/azure-swa/vite.config.ts && touch dist/index.html && rm dist/app/index.html",
     "build.client": "vite build",
     "build.client.debug": "node --inspect-brk ./node_modules/vite/bin/vite.js build",
     "build.cloudflare": "npm run build.client && vite build -c adapters/cloudflare-pages/vite.config.ts",


### PR DESCRIPTION
The new structure does not creat an index.html file in dist (which Azure needs). But it creates an empty index.html in dist/app which Azure will serve instead of calling the backend. Both issues can be fixed by rm and touch but this is not a nice solution.